### PR TITLE
Fix vehicle model with make

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Change log itself follows [Keep a CHANGELOG](http://keepachangelog.com) format.
 - `Faker.Address.Ru.country/0` [[@igas][]]
 - `Faker.Address.Ru.state/0` [[@igas][]]
 - `Faker.Gov.It` [[@neslinesli93](https://github.com/neslinesli93)]
+- `Faker.Vehicle.model/1` [[@daytonn][https://github/com/daytonn]]
 
 ### Changed
 

--- a/lib/faker/vehicle.ex
+++ b/lib/faker/vehicle.ex
@@ -107,6 +107,24 @@ defmodule Faker.Vehicle do
   localize(:model)
 
   @doc """
+  Returns a vehicle model string belonging to the given make
+
+  ## Examples
+      iex> Faker.Vehicle.model("Ford")
+      "Focus"
+      iex> Faker.Vehicle.model("BMW")
+      "X5"
+      iex> Faker.Vehicle.model("Audi")
+      "A4"
+      iex> Faker.Vehicle.model("Toyota")
+      "Corolla"
+  """
+  @spec model(String.t()) :: String.t()
+  def model(make) do
+    En.model(make)
+  end
+
+  @doc """
   Returns a vehicle option string
 
   ## Examples
@@ -119,6 +137,7 @@ defmodule Faker.Vehicle do
       iex> Faker.Vehicle.option()
       "Keyless Entry"
   """
+
   @spec option() :: String.t()
   localize(:option)
 


### PR DESCRIPTION
This PR adds a missing function to the `Vehicle` module. There is a form of the `Vehicle.En.model` function that takes a make and returns a make belonging to the given model. I missed adding that form to the `Vehicle` module. This PR corrects that.
I've added:

- [x] USAGE.md docs if applicable
- [x] CHANGELOG.md
- [x] `Faker.Vehicle.model/1`
