### PR TITLE
Fix Faker.Code.Iban.iban and Faker.Gov.It.fiscal_id doctests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Change log itself follows [Keep a CHANGELOG](http://keepachangelog.com) format.
 
 ### Added
 
+- Remove extra `Faker.Code.Iban.iban` doctests [[@vbrazo](https://github.com/vbrazo)]
 - `Faker.Pokemon.It.location/0` [[@fusillicode](https://github.com/fusillicode)]
 - `Faker.Pokemon.It.name/0` [[@fusillicode](https://github.com/fusillicode)]
 - `Faker.Color.De.name/0` [[@hlhr](https://github.com/hlhr)]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Change log itself follows [Keep a CHANGELOG](http://keepachangelog.com) format.
 
 ### Added
 
-- Remove extra `Faker.Code.Iban.iban` doctests [[@vbrazo](https://github.com/vbrazo)]
+- Fix `Faker.Code.Iban.iban` and `Faker.Gov.It.fiscal_id` doctests [[@vbrazo](https://github.com/vbrazo)]
 - `Faker.Pokemon.It.location/0` [[@fusillicode](https://github.com/fusillicode)]
 - `Faker.Pokemon.It.name/0` [[@fusillicode](https://github.com/fusillicode)]
 - `Faker.Color.De.name/0` [[@hlhr](https://github.com/hlhr)]

--- a/lib/faker/code/iban.ex
+++ b/lib/faker/code/iban.ex
@@ -18,8 +18,6 @@ defmodule Faker.Code.Iban do
       "NL74YRFX4598109960"
       iex> Faker.Code.Iban.iban(["NL", "BE"])
       "BE31198979502980"
-      iex> Faker.Code.Iban.iban("NL", ["ABNA"])
-      "NL79ABNA7856869061"
   """
 
   @alpha ~w(A B C D E F G H I J K L M N O P Q R S T U V W X Y Z)

--- a/lib/faker/gov/it.ex
+++ b/lib/faker/gov/it.ex
@@ -19,6 +19,8 @@ defmodule Faker.Gov.It do
       "ZSLNKH22M34H480J"
       iex> Faker.Gov.It.fiscal_id
       "OCPCVO90M50F353I"
+      iex> Faker.Gov.It.fiscal_id
+      "PQYRFX94R54C681K"
   """
   @spec fiscal_id() :: binary()
   def fiscal_id do


### PR DESCRIPTION
I've added:

- [ ] USAGE.md docs if applicable
- [x] CHANGELOG.md

Doctests should have 4 examples and `Faker.Code.Iban.iban` had extra doctests while `Faker.Gov.It.fiscal_id` was missing 1 doctest.
