### PR TITLE
Fixed issue with Date.date_of_birth/1 using invalid date range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ Change log itself follows [Keep a CHANGELOG](http://keepachangelog.com) format.
 
 ### Fixed
 
+- `Faker.Date.date_of_birth/1` generating invalid date range on last day of the month [[@anthonator](https://github.com/anthonator)]
+
 ### Security
 
 ## 0.14.0

--- a/lib/faker/date.ex
+++ b/lib/faker/date.ex
@@ -12,33 +12,20 @@ defmodule Faker.Date do
   def date_of_birth(age_or_range \\ 18..99)
 
   def date_of_birth(age) when is_integer(age) do
-    {{year_now, month_now, day_now}, _time} = :calendar.local_time()
+    {date, _time} = :calendar.local_time()
 
-    earliest_year = year_now - (age + 1)
+    today = Date.from_erl!(date)
 
-    potential_earliest_date = {earliest_year, month_now, day_now + 1}
-    potential_latest_date = {earliest_year + 1, month_now, day_now}
+    earliest_year = today.year - (age + 1)
 
-    earliest_date =
-      if :calendar.valid_date(potential_earliest_date),
-        do: {earliest_year, month_now, day_now + 1},
-        else: {earliest_year, 3, 1}
+    {:ok, earliest_date} = Date.new(earliest_year, today.month, today.day)
+    earliest_date = Date.add(earliest_date, 1)
 
-    latest_date =
-      if :calendar.valid_date(potential_latest_date),
-        do: {earliest_year + 1, month_now, day_now},
-        else: {earliest_year + 1, 2, 28}
+    {:ok, latest_date} = Date.new(earliest_year + 1, today.month, today.day)
 
-    earliest_as_seconds = :calendar.datetime_to_gregorian_seconds({earliest_date, {0, 0, 0}})
-    lastest_as_seconds = :calendar.datetime_to_gregorian_seconds({latest_date, {23, 59, 59}})
+    date_range = Date.range(earliest_date, latest_date)
 
-    {chosen_date, _time} =
-      earliest_as_seconds..lastest_as_seconds
-      |> pick()
-      |> :calendar.gregorian_seconds_to_datetime()
-
-    {:ok, result} = Date.from_erl(chosen_date)
-    result
+    pick(date_range)
   end
 
   def date_of_birth(age_range) do


### PR DESCRIPTION
This is one of those insidious date issues that only appear on specific dates.

Currently, when `Date.date_of_birth/1` generates a potential date range it will create an "earliest potential date" that is `today + 1`.

https://github.com/elixirs/faker/blob/master/lib/faker/date.ex#L19

This will always be invalid on the last day of the month. In the event the date is invalid a hard coded date of `3/1` is used. This has the side effect of generating a date that has the potential to be outside the allowed date range. I believe the later in the year it is the more likely this is to happen.

This pull request uses Elixir's built in date manipulation functions to properly modify dates. Eliminating the possibility of invalid dates being generated.

I've added:

- ~[ ] USAGE.md docs if applicable~
- [x] CHANGELOG.md
