### PR TITLE
feature: added in a way to control the options passed to the avatar 

### DIFF
--- a/lib/faker/avatar.ex
+++ b/lib/faker/avatar.ex
@@ -21,7 +21,7 @@ defmodule Faker.Avatar do
   """
   @spec image_url() :: String.t()
   def image_url do
-    "http://robohash.org#{set()}#{bg()}/#{Lorem.characters(1..20)}"
+    image_url_with_opts()
   end
 
   @doc """
@@ -40,7 +40,7 @@ defmodule Faker.Avatar do
   """
   @spec image_url(binary) :: String.t()
   def image_url(slug) do
-    "http://robohash.org/#{slug}"
+    image_url_with_opts(slug: slug, ssl: false, raw: true)
   end
 
   @doc """
@@ -50,19 +50,26 @@ defmodule Faker.Avatar do
   ## Examples
 
       iex> Faker.Avatar.image_url(200, 200)
-      "http://robohash.org/set_set2/bgset_bg2/ppkQqaIfGqx?size=200x200"
+      "http://robohash.org/set_set1/bgset_bg2/kQqaIfGqxsjFoNIT?size=200x200"
       iex> Faker.Avatar.image_url(800, 600)
-      "http://robohash.org/set_set2/bgset_bg2/oNITNnu6?size=800x600"
+      "http://robohash.org/set_set2/bgset_bg2/6?size=800x600"
       iex> Faker.Avatar.image_url(32, 32)
-      "http://robohash.org/set_set3/bgset_bg1/J?size=32x32"
+      "http://robohash.org/set_set2/bgset_bg2/J?size=32x32"
       iex> Faker.Avatar.image_url(128, 128)
-      "http://robohash.org/set_set1/bgset_bg2/JNth88PrhGDhwp4LNQMt?size=128x128"
+      "http://robohash.org/set_set3/bgset_bg1/JNth88PrhGDhwp4LNQMt?size=128x128"
   """
   @spec image_url(integer, integer) :: String.t()
   def image_url(width, height)
       when is_integer(width) and is_integer(height) do
-    slug = Lorem.characters(1..20)
-    "http://robohash.org#{set()}#{bg()}/#{slug}?size=#{width}x#{height}"
+    image_url_with_opts(
+      ssl: false,
+      raw: false,
+      set: nil,
+      bg: nil,
+      slug: nil,
+      height: height,
+      width: width
+    )
   end
 
   @doc """
@@ -82,21 +89,114 @@ defmodule Faker.Avatar do
   @spec image_url(binary, integer, integer) :: String.t()
   def image_url(slug, width, height)
       when is_integer(width) and is_integer(height) do
-    "http://robohash.org/#{slug}?size=#{width}x#{height}"
+    image_url_with_opts(
+      ssl: false,
+      raw: true,
+      set: nil,
+      bg: nil,
+      slug: slug,
+      height: height,
+      width: width
+    )
+  end
+
+  @doc """
+    Return avatar url for given set of options. This gives you more control of how the
+    url is generated.
+
+  Options -
+  * ssl - boolean - true - returns an https:// url
+  * bg - integer - the background set to use for the image
+  * set - integer - the image set to use for the image
+  * slug - string - a string used to generate the hash
+  * raw - boolean - true - does not generate a random set/bg for the image
+  * height - integer - the height in pixels of the image
+  * width - integer - the width in pixels of the image
+
+
+  """
+  @spec image_url_with_opts(
+          ssl: boolean(),
+          set: integer(),
+          bg: integer(),
+          raw: boolean(),
+          slug: String.t(),
+          height: integer(),
+          width: integer
+        ) :: String.t()
+  def image_url_with_opts(
+        opts \\ [
+          ssl: false,
+          set: nil,
+          bg: nil,
+          raw: false,
+          slug: nil,
+          height: nil,
+          width: nil
+        ]
+      ) do
+    opt_map =
+      Enum.into(opts, %{
+        ssl: false,
+        set: nil,
+        bg: nil,
+        raw: false,
+        slug: nil,
+        height: nil,
+        width: nil
+      })
+
+    "#{robohash_url(opt_map[:ssl])}#{set_url(opt_map)}#{bg_url(opt_map)}/#{slug(opt_map)}#{
+      query(opt_map)
+    }"
+  end
+
+  defp slug(%{slug: nil}), do: random_slug()
+  defp slug(%{slug: value}), do: value
+  defp slug(_), do: random_slug()
+
+  defp query(%{height: height, width: width}) when is_integer(height) and is_integer(width) do
+    "?size=#{width}x#{height}"
+  end
+
+  defp query(_), do: ""
+
+  defp random_slug(), do: "#{Lorem.characters(1..20)}"
+  defp set_url(%{raw: true}), do: ""
+  defp set_url(%{raw: false, set: nil}), do: set()
+  defp set_url(%{raw: false, set: set_value}), do: set_to_url(set_value)
+  defp bg_url(%{raw: true}), do: ""
+  defp bg_url(%{raw: false, bg: nil}), do: bg()
+  defp bg_url(%{raw: false, bg: bg_value}), do: bg_to_url(bg_value)
+
+  defp robohash_url(true) do
+    "https://robohash.org"
+  end
+
+  defp robohash_url(_) do
+    "http://robohash.org"
+  end
+
+  defp bg_to_url(number) do
+    case number do
+      2 -> "/bgset_bg2"
+      _ -> "/bgset_bg1"
+    end
+  end
+
+  defp set_to_url(number) do
+    case number do
+      2 -> "/set_set2"
+      3 -> "/set_set3"
+      _ -> "/set_set1"
+    end
   end
 
   defp bg do
-    %{
-      0 => "/bgset_bg1",
-      1 => "/bgset_bg2"
-    }[Faker.random_between(0, 1)]
+    bg_to_url(Faker.random_between(1, 2))
   end
 
   defp set do
-    %{
-      0 => "/set_set1",
-      1 => "/set_set2",
-      2 => "/set_set3"
-    }[Faker.random_between(0, 2)]
+    set_to_url(Faker.random_between(1, 3))
   end
 end

--- a/test/faker/avatar_test.exs
+++ b/test/faker/avatar_test.exs
@@ -9,17 +9,41 @@ defmodule Faker.AvatarTest do
     assert String.starts_with?(image_url(), "http://robohash.org/")
   end
 
-  test "image_url/1" do
-    assert String.starts_with?(image_url("myslug"), "http://robohash.org/")
-    assert String.contains?(image_url("myslug"), "myslug")
-  end
+    test "image_url/1" do
+      assert String.starts_with?(image_url("myslug"), "http://robohash.org/")
+      assert String.contains?(image_url("myslug"), "myslug")
+    end
 
-  test "image_url/2" do
-    assert String.contains?(image_url(40, 60), "40x60")
-  end
+    test "image_url/2" do
+      assert String.contains?(image_url(40, 60), "40x60")
+    end
 
-  test "image_url/3" do
-    assert String.contains?(image_url("myslug", 70, 20), "70x20")
-    assert String.contains?(image_url("myslug", 70, 20), "myslug")
-  end
+    test "image_url/3" do
+      assert String.contains?(image_url("myslug", 70, 20), "70x20")
+      assert String.contains?(image_url("myslug", 70, 20), "myslug")
+    end
+
+
+    test "image_url_with/0" do
+      assert String.starts_with?(image_url_with_opts(), "http://robohash.org/")
+      assert String.contains?(image_url_with_opts(), "/set_set")
+      assert String.contains?(image_url_with_opts(), "/bgset_bg")
+    end
+
+    test "image_url_with_opts/1" do
+
+
+
+      assert image_url_with_opts(ssl: true, set: 2, bg: 2, slug: "hello", height: 20, width: 10) == "https://robohash.org/set_set2/bgset_bg2/hello?size=10x20"
+      assert image_url_with_opts(ssl: false, set: 2, bg: 2, slug: "hello", height: 20, width: 10) == "http://robohash.org/set_set2/bgset_bg2/hello?size=10x20"
+
+
+      assert String.starts_with?(image_url_with_opts(ssl: true,  slug: "hello", height: 20, width: 10), "https://robohash.org/")
+      assert String.contains?(image_url_with_opts(ssl: true,  slug: "hello", height: 20, width: 10), "hello?size=10x20")
+
+
+      assert String.contains?(image_url_with_opts(ssl: true,  slug: "hello"), "hello")
+
+    end
+
 end


### PR DESCRIPTION

I've added: added 

Faker.Avatar.image_url_with_opts()  - this allows you to control more of the options related to generating a robohash.org url. It started because I needed to be able to turn on ssl in the url (our dev environments run in ssl). I reworked the existing library to use the new method. It does not change any behavior on the existing methods.

- [ ] USAGE.md docs if applicable
- [ ] CHANGELOG.md
