### PR TITLE
doc: fix team doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ Change log itself follows [Keep a CHANGELOG](http://keepachangelog.com) format.
 
 ### Fixed
 
+- `Faker.Team` `creature/0` and `name/0` documentation examples fixed [[@yuriploc](https://github.com/yuriploc)]
+
 ### Security
 
 ## 0.16.0

--- a/lib/faker/team.ex
+++ b/lib/faker/team.ex
@@ -10,14 +10,14 @@ defmodule Faker.Team do
 
   ## Examples
 
-      iex> Faker.Team.name()
-      "Hawaii cats"
-      iex> Faker.Team.name()
-      "Oklahoma banshees"
-      iex> Faker.Team.name()
-      "Texas elves"
-      iex> Faker.Team.name()
-      "Iowa fishes"
+      iex> Faker.Team.creature()
+      "prophets"
+      iex> Faker.Team.creature()
+      "cats"
+      iex> Faker.Team.creature()
+      "enchanters"
+      iex> Faker.Team.creature()
+      "banshees"
   """
   @spec creature() :: String.t()
   localize(:creature)
@@ -27,14 +27,14 @@ defmodule Faker.Team do
 
   ## Examples
 
-      iex> Faker.Team.creature()
-      "prophets"
-      iex> Faker.Team.creature()
-      "cats"
-      iex> Faker.Team.creature()
-      "enchanters"
-      iex> Faker.Team.creature()
-      "banshees"
+      iex> Faker.Team.name()
+      "Hawaii cats"
+      iex> Faker.Team.name()
+      "Oklahoma banshees"
+      iex> Faker.Team.name()
+      "Texas elves"
+      iex> Faker.Team.name()
+      "Iowa fishes"
   """
   @spec name() :: String.t()
   localize(:name)


### PR DESCRIPTION
Hi there. By reading the docs for examples on the [Team module](https://hexdocs.pm/faker/Faker.Team.html#content) I've found this mismatch on the examples section.

> The examples were changed between `name/0` and `creature/0`

I've added:

- [ ] USAGE.md docs if applicable
- [x] CHANGELOG.md
