### PR TITLE
Dwelling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Change log itself follows [Keep a CHANGELOG](http://keepachangelog.com) format.
 ## Unreleased
 
 ### Added
+- `Faker.Dwelling` [[@winescout](https://github.com/winescout)]
+- `Faker.Dwelling.En` [[@winescout](https://github.com/winescout)]
 
 ### Changed
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -44,6 +44,8 @@
 - [Faker.Date](lib/faker/date.ex)
 - [Faker.DateTime](lib/faker/datetime.ex)
 - [Faker.Dog.PtBr](lib/faker/dog/pt_br.ex)
+- [Faker.Dwelling](lib/faker/dwelling.ex)
+- [Faker.Dwelling.En](lib/faker/dwelling/en.ex)
   <!-- E -->
   <!-- F -->
 - [Faker.File](lib/faker/file.ex)

--- a/lib/faker/dwelling.ex
+++ b/lib/faker/dwelling.ex
@@ -11,13 +11,13 @@ defmodule Faker.Dwelling do
 
   ## Examples 
       iex> Faker.Dwelling.dwelling_type()
-      "Cycladic house"
+      "cycladic house"
       iex> Faker.Dwelling.dwelling_type()
-      "Shepard's hut"
+      "shepard's hut"
       iex> Faker.Dwelling.dwelling_type()
-      "Cycladic house"
+      "cycladic house"
       iex> Faker.Dwelling.dwelling_type()
-      "Earth house"
+      "earth house"
   """
 
   @spec dwelling_type :: String.t()

--- a/lib/faker/dwelling.ex
+++ b/lib/faker/dwelling.ex
@@ -23,4 +23,19 @@ defmodule Faker.Dwelling do
   @spec dwelling_type :: String.t()
   localize(:dwelling_type)
 
+  @doc """
+  Returns a room name string
+
+  ## Examples
+      iex> Faker.Dwelling.room()
+      "kitchen"
+      iex> Faker.Dwelling.room()
+      "bathroom"
+      iex> Faker.Dwelling.room()
+      "dining room"
+      iex> Faker.Dwelling.room()
+      "living room"
+  """
+  @spec room :: String.t()
+  localize(:room)
 end

--- a/lib/faker/dwelling.ex
+++ b/lib/faker/dwelling.ex
@@ -1,0 +1,26 @@
+defmodule Faker.Dwelling do 
+  import Faker, only: [localize: 1]
+
+
+  @moduledoc """
+  Functions for generating Dwelling related data
+  """
+
+  @doc """
+  Returns a dwelling type string
+
+  ## Examples 
+      iex> Faker.Dwelling.dwelling_type()
+      "Cycladic house"
+      iex> Faker.Dwelling.dwelling_type()
+      "Shepard's hut"
+      iex> Faker.Dwelling.dwelling_type()
+      "Cycladic house"
+      iex> Faker.Dwelling.dwelling_type()
+      "Earth house"
+  """
+
+  @spec dwelling_type :: String.t()
+  localize(:dwelling_type)
+
+end

--- a/lib/faker/dwelling/en.ex
+++ b/lib/faker/dwelling/en.ex
@@ -40,4 +40,31 @@ defmodule Faker.Dwelling.En do
     "Trulio",
     "Villa",
   ])
+
+  @doc """
+  Returns a room name string
+
+  ## Examples
+      iex> Faker.Dwelling.En.room()
+      "kitchen"
+      iex> Faker.Dwelling.En.room()
+      "bathroom"
+      iex> Faker.Dwelling.En.room()
+      "dining room"
+      iex> Faker.Dwelling.En.room()
+      "living room"
+  """
+  @spec room :: String.t()
+  sampler(:room, [
+    "kitchen",
+    "bathroom",
+    "bedroom",
+    "master bedroom",
+    "living room",
+    "dining room",
+    "entry way",
+    "garage",
+    "laundry room",
+    "basement"
+  ])
 end

--- a/lib/faker/dwelling/en.ex
+++ b/lib/faker/dwelling/en.ex
@@ -1,0 +1,43 @@
+defmodule Faker.Dwelling.En do
+  import Faker, only: [sampler: 2]
+
+  @moduledoc """
+  Functions for generating Dwelling related data in English
+  """
+
+  @doc """
+  Returns a dwelling type string
+
+  ## Examples
+      iex> Faker.Dwelling.dwelling_type()
+      "Cycladic house"
+      iex> Faker.Dwelling.dwelling_type()
+      "Shepard's hut"
+      iex> Faker.Dwelling.dwelling_type()
+      "Cycladic house"
+      iex> Faker.Dwelling.dwelling_type()
+      "Earth house"
+  """
+  @spec dwelling_type() :: String.t()
+  sampler(:dwelling_type, [
+    "Bungalow",
+    "Cabin",
+    "Casa Particular",
+    "Chalet",
+    "Cottage",
+    "Cycladic house",
+    "Dammuso",
+    "Dome house",
+    "Earth house",
+    "House",
+    "Houseboat",
+    "Hut",
+    "Lighthouse",
+    "Pension",
+    "Shepard's hut",
+    "Tiny house",
+    "Townhouse",
+    "Trulio",
+    "Villa",
+  ])
+end

--- a/lib/faker/dwelling/en.ex
+++ b/lib/faker/dwelling/en.ex
@@ -10,35 +10,35 @@ defmodule Faker.Dwelling.En do
 
   ## Examples
       iex> Faker.Dwelling.dwelling_type()
-      "Cycladic house"
+      "cycladic house"
       iex> Faker.Dwelling.dwelling_type()
-      "Shepard's hut"
+      "shepard's hut"
       iex> Faker.Dwelling.dwelling_type()
-      "Cycladic house"
+      "cycladic house"
       iex> Faker.Dwelling.dwelling_type()
-      "Earth house"
+      "earth house"
   """
   @spec dwelling_type() :: String.t()
   sampler(:dwelling_type, [
-    "Bungalow",
-    "Cabin",
-    "Casa Particular",
-    "Chalet",
-    "Cottage",
-    "Cycladic house",
-    "Dammuso",
-    "Dome house",
-    "Earth house",
-    "House",
-    "Houseboat",
-    "Hut",
-    "Lighthouse",
-    "Pension",
-    "Shepard's hut",
-    "Tiny house",
-    "Townhouse",
-    "Trulio",
-    "Villa",
+    "bungalow",
+    "cabin",
+    "casa particular",
+    "chalet",
+    "cottage",
+    "cycladic house",
+    "dammuso",
+    "dome house",
+    "earth house",
+    "house",
+    "houseboat",
+    "hut",
+    "lighthouse",
+    "pension",
+    "shepard's hut",
+    "tiny house",
+    "townhouse",
+    "trulio",
+    "villa",
   ])
 
   @doc """

--- a/test/faker/dwelling_test.exs
+++ b/test/faker/dwelling_test.exs
@@ -1,0 +1,6 @@
+defmodule Faker.HomeTest do
+  use ExUnit.Case, async: true
+
+  doctest Faker.Dwelling
+  doctest Faker.Dwelling.En
+end


### PR DESCRIPTION
I've added:

- [x] USAGE.md docs if applicable
- [x] CHANGELOG.md

In this PR
=============
Adds dwelling types and room types under a Dwelling module.  Useful when working on real estate type applications

Discussion
=============
In the tests for dwelling_type there is a duplicate test for "cycladic house".  The tests are green, but is this to be expected?
