### PR TITLE
Add Vehicle Makes and Models, module cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Change log itself follows [Keep a CHANGELOG](http://keepachangelog.com) format.
 - `Faker.Internet.StatusCode` [[@emmetreza](https://github.com/emmetreza)]
 
 ### Changed
+- `Faker.Vehicles` add makes and models that are multi-word, refactor existing fns [[jersearls](https://github.com/jersearls)]
 
 - `Faker.Avatar` switch to `https` to prevent redirect [[igas](https://github.com/igas)]
 

--- a/lib/faker/vehicle.ex
+++ b/lib/faker/vehicle.ex
@@ -61,13 +61,13 @@ defmodule Faker.Vehicle do
   ## Examples
 
       iex> Faker.Vehicle.make()
-      "BMW"
-      iex> Faker.Vehicle.make()
-      "Audi"
+      "Lincoln"
       iex> Faker.Vehicle.make()
       "Dodge"
       iex> Faker.Vehicle.make()
-      "Ford"
+      "Chevy"
+      iex> Faker.Vehicle.make()
+      "Honda"
   """
   @spec make() :: String.t()
   localize(:make)
@@ -78,11 +78,11 @@ defmodule Faker.Vehicle do
   ## Examples
 
       iex> Faker.Vehicle.make_and_model()
-      "BMW X5"
+      "Lincoln MKZ"
       iex> Faker.Vehicle.make_and_model()
-      "Dodge Ram"
+      "Chevy Malibu"
       iex> Faker.Vehicle.make_and_model()
-      "Toyota Prius"
+      "Ford Focus"
       iex> Faker.Vehicle.make_and_model()
       "Ford Focus"
   """
@@ -95,13 +95,13 @@ defmodule Faker.Vehicle do
   ## Examples
 
       iex> Faker.Vehicle.model()
-      "CR-V"
-      iex> Faker.Vehicle.model()
-      "Enclave"
-      iex> Faker.Vehicle.model()
       "Encore"
       iex> Faker.Vehicle.model()
-      "Verano"
+      "S5"
+      iex> Faker.Vehicle.model()
+      "Fiesta"
+      iex> Faker.Vehicle.model()
+      "X1"
   """
   @spec model() :: String.t()
   localize(:model)

--- a/lib/faker/vehicle/en.ex
+++ b/lib/faker/vehicle/en.ex
@@ -16,7 +16,9 @@ defmodule Faker.Vehicle.En do
     "Lincoln",
     "Buick",
     "Honda",
-    "Nissan"
+    "Nissan",
+    "Mercedes-Benz",
+    "Aston Martin"
   ]
 
   @models %{
@@ -29,7 +31,9 @@ defmodule Faker.Vehicle.En do
     "Lincoln" => ["Navigator", "MKZ", "MKX", "MKS"],
     "Buick" => ["Enclave", "Regal", "LaCrosse", "Verano", "Encore", "Riveria"],
     "Honda" => ["Accord", "Civic", "CR-V", "Odyssey"],
-    "Nissan" => ["Rogue", "Juke", "Cube", "Pathfiner", "Versa", "Altima"]
+    "Nissan" => ["Rogue", "Juke", "Cube", "Pathfinder", "Versa", "Altima"],
+    "Mercedes-Benz" => ["AMG GLB 35", "B-Class Electric Drive", "G 550 4x4 Squared"],
+    "Aston Martin" => ["DB AR1 Zagato", "DB7 Vantage", "V8 Vantage S"]
   }
 
   @options [
@@ -262,8 +266,11 @@ defmodule Faker.Vehicle.En do
     "Tire pressure monitoring display"
   ]
 
+  @spec all_models :: [String.t()]
   defp all_models do
-    Enum.reduce(Map.values(@models), [], fn models, acc -> acc ++ models end)
+    @models
+    |> Map.values()
+    |> Enum.concat()
   end
 
   @doc """
@@ -341,13 +348,13 @@ defmodule Faker.Vehicle.En do
   ## Examples
 
       iex> Faker.Vehicle.En.make()
-      "BMW"
-      iex> Faker.Vehicle.En.make()
-      "Audi"
+      "Lincoln"
       iex> Faker.Vehicle.En.make()
       "Dodge"
       iex> Faker.Vehicle.En.make()
-      "Ford"
+      "Chevy"
+      iex> Faker.Vehicle.En.make()
+      "Honda"
   """
   @spec make() :: String.t()
   def make do
@@ -360,18 +367,18 @@ defmodule Faker.Vehicle.En do
   ## Examples
 
       iex> Faker.Vehicle.En.make_and_model()
-      "BMW X5"
+      "Lincoln MKZ"
       iex> Faker.Vehicle.En.make_and_model()
-      "Dodge Ram"
+      "Chevy Malibu"
       iex> Faker.Vehicle.En.make_and_model()
-      "Toyota Prius"
+      "Ford Focus"
       iex> Faker.Vehicle.En.make_and_model()
       "Ford Focus"
   """
   @spec make_and_model() :: String.t()
   def make_and_model do
-    m = make()
-    "#{m} #{model(m)}"
+    make = make()
+    "#{make} #{model(make)}"
   end
 
   @doc """
@@ -380,13 +387,13 @@ defmodule Faker.Vehicle.En do
   ## Examples
 
       iex> Faker.Vehicle.En.model()
-      "CR-V"
-      iex> Faker.Vehicle.En.model()
-      "Enclave"
-      iex> Faker.Vehicle.En.model()
       "Encore"
       iex> Faker.Vehicle.En.model()
-      "Verano"
+      "S5"
+      iex> Faker.Vehicle.En.model()
+      "Fiesta"
+      iex> Faker.Vehicle.En.model()
+      "X1"
   """
   @spec model() :: String.t()
   def model do
@@ -408,15 +415,10 @@ defmodule Faker.Vehicle.En do
       iex> Faker.Vehicle.En.model("Toyota")
       "Corolla"
   """
-
   @spec model(String.t()) :: String.t()
-  def model(make) do
-    if Enum.member?(@makes, make) do
-      Util.pick(@models[make])
-    else
-      model()
-    end
-  end
+  def model(make) when make in @makes, do: Util.pick(@models[make])
+
+  def model(_make), do: model()
 
   @doc """
   Returns a vehicle option string


### PR DESCRIPTION
## What

Adds:
- [x] CHANGELOG.md
- [x] Refactors `all_models/0`and `model/1`
- [x] Adds two makes
- [x] Adds corresponding models

## Why

Having Vehicle makes and models that include hyphens and white space will create more robust tests for `Vehicle` module users. This reflects real world make and model data structures.



