### PR TITLE
GitHub Actions badge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,8 @@ Change log itself follows [Keep a CHANGELOG](http://keepachangelog.com) format.
 
 ### Changed
 - `Faker.Vehicles` add makes and models that are multi-word, refactor existing fns [[jersearls](https://github.com/jersearls)]
-
 - `Faker.Avatar` switch to `https` to prevent redirect [[igas](https://github.com/igas)]
+- Updated build badge for GitHub Actions [[@anthonator](https://github.com/anthonator)]
 
 ### Deprecated
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Faker
 
-[![Build Status](https://img.shields.io/travis/elixirs/faker.svg?style=flat-square)](https://travis-ci.org/elixirs/faker)
+[![build](https://github.com/elixirs/faker/actions/workflows/ci.yaml/badge.svg)](https://github.com/elixirs/faker/actions/workflows/ci.yaml)
 [![Version](https://img.shields.io/hexpm/v/faker.svg?style=flat-square)](https://hex.pm/packages/faker)
 [![Hex Docs](https://img.shields.io/badge/hex-docs-lightgreen.svg)](https://hexdocs.pm/faker/)
 [![License](https://img.shields.io/hexpm/l/faker.svg?style=flat-square)](https://github.com/elixirs/faker/blob/master/LICENSE)


### PR DESCRIPTION
Updated badge on README to use GitHub Actions instead of Travis.

I've added:

- ~[ ] USAGE.md docs if applicable~
- [x] CHANGELOG.md
