### PR TITLE
Release 0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ Change log itself follows [Keep a CHANGELOG](http://keepachangelog.com) format.
 ## Unreleased
 
 ### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+## 0.17.0
+
+### Added
 - `Faker.Internet.StatusCode` [[@emmetreza](https://github.com/emmetreza)]
 - CI workflow using GitHub Actions [[@anthonator](https://github.com/anthonator)]
 - `Faker.Cat.PtBr` [[@f-francine](https://github.com/f-francine)]

--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ fake data.
 
 ## Quickstart
 
-* add `{:faker, "~> 0.16"}` to your deps in `mix.exs`:
+* add `{:faker, "~> 0.17"}` to your deps in `mix.exs`:
 
     ```elixir
     defp deps do
-      [{:faker, "~> 0.16", only: :test}]
+      [{:faker, "~> 0.17", only: :test}]
     end
     ```
 

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Faker.Mixfile do
   use Mix.Project
 
   @source_url "https://github.com/elixirs/faker"
-  @version "0.16.0"
+  @version "0.17.0"
 
   def project do
     [


### PR DESCRIPTION
I've added:

- ~[ ] USAGE.md docs if applicable~
- ~[ ] CHANGELOG.md~

@igas @vbrazo given the current release of faker is broke with Elixir 1.13.0 I thought it was important to get a new release out. We also haven't released in a while. This pull request prepares the project for version 0.17.0.