### PR TITLE
Fix spelling of some vehicle makes/models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Change log itself follows [Keep a CHANGELOG](http://keepachangelog.com) format.
 - `Faker.Commerce.PtBr` - add more products in product_name_product [[@igorgbr](https://github.com/igorgbr)]
 - `Faker.Fruits.PtBr` - fix typo in nectarina [[@KevinDaSilvaS](https://github.com/KevinDaSilvaS)]
 - `Faker.Internet.image_url/0` - switched unresponsive placeholder.it with picsum.photos [[@almirsarajcic](https://github.com/almirsarajcic)]
+- `Faker.Vehicle.En` - fix spelling of some common makes/models [[@nskins](https://github.com/nskins)]
 
 ### Deprecated
 

--- a/lib/faker/vehicle.ex
+++ b/lib/faker/vehicle.ex
@@ -65,7 +65,7 @@ defmodule Faker.Vehicle do
       iex> Faker.Vehicle.make()
       "Dodge"
       iex> Faker.Vehicle.make()
-      "Chevy"
+      "Chevrolet"
       iex> Faker.Vehicle.make()
       "Honda"
   """
@@ -80,7 +80,7 @@ defmodule Faker.Vehicle do
       iex> Faker.Vehicle.make_and_model()
       "Lincoln MKZ"
       iex> Faker.Vehicle.make_and_model()
-      "Chevy Malibu"
+      "Chevrolet Malibu"
       iex> Faker.Vehicle.make_and_model()
       "Ford Focus"
       iex> Faker.Vehicle.make_and_model()

--- a/lib/faker/vehicle/en.ex
+++ b/lib/faker/vehicle/en.ex
@@ -29,7 +29,7 @@ defmodule Faker.Vehicle.En do
     "Ford" => ["Mustang", "F-150", "Focus", "Fiesta"],
     "Dodge" => ["Ram", "Challenger", "Charger", "Durango"],
     "Lincoln" => ["Navigator", "MKZ", "MKX", "MKS"],
-    "Buick" => ["Enclave", "Regal", "LaCrosse", "Verano", "Encore", "Riveria"],
+    "Buick" => ["Enclave", "Regal", "LaCrosse", "Verano", "Encore", "Riviera"],
     "Honda" => ["Accord", "Civic", "CR-V", "Odyssey"],
     "Nissan" => ["Rogue", "Juke", "Cube", "Pathfinder", "Versa", "Altima"],
     "Mercedes-Benz" => ["AMG GLB 35", "B-Class Electric Drive", "G 550 4x4 Squared"],

--- a/lib/faker/vehicle/en.ex
+++ b/lib/faker/vehicle/en.ex
@@ -10,7 +10,7 @@ defmodule Faker.Vehicle.En do
     "BMW",
     "Audi",
     "Toyota",
-    "Chevy",
+    "Chevrolet",
     "Ford",
     "Dodge",
     "Lincoln",
@@ -25,7 +25,7 @@ defmodule Faker.Vehicle.En do
     "BMW" => ["328i", "M3", "M5", "X1", "X3", "X5"],
     "Audi" => ["A4", "A5", "S5", "A7", "A8"],
     "Toyota" => ["Prius", "Camry", "Corolla"],
-    "Chevy" => ["Camero", "Silverado", "Malibu"],
+    "Chevrolet" => ["Camero", "Silverado", "Malibu"],
     "Ford" => ["Mustang", "F150", "Focus", "Fiesta"],
     "Dodge" => ["Ram", "Challenger", "Charger", "Durango"],
     "Lincoln" => ["Navigator", "MKZ", "MKX", "MKS"],
@@ -352,7 +352,7 @@ defmodule Faker.Vehicle.En do
       iex> Faker.Vehicle.En.make()
       "Dodge"
       iex> Faker.Vehicle.En.make()
-      "Chevy"
+      "Chevrolet"
       iex> Faker.Vehicle.En.make()
       "Honda"
   """
@@ -369,7 +369,7 @@ defmodule Faker.Vehicle.En do
       iex> Faker.Vehicle.En.make_and_model()
       "Lincoln MKZ"
       iex> Faker.Vehicle.En.make_and_model()
-      "Chevy Malibu"
+      "Chevrolet Malibu"
       iex> Faker.Vehicle.En.make_and_model()
       "Ford Focus"
       iex> Faker.Vehicle.En.make_and_model()

--- a/lib/faker/vehicle/en.ex
+++ b/lib/faker/vehicle/en.ex
@@ -25,7 +25,7 @@ defmodule Faker.Vehicle.En do
     "BMW" => ["328i", "M3", "M5", "X1", "X3", "X5"],
     "Audi" => ["A4", "A5", "S5", "A7", "A8"],
     "Toyota" => ["Prius", "Camry", "Corolla"],
-    "Chevrolet" => ["Camero", "Silverado", "Malibu"],
+    "Chevrolet" => ["Camaro", "Silverado", "Malibu"],
     "Ford" => ["Mustang", "F150", "Focus", "Fiesta"],
     "Dodge" => ["Ram", "Challenger", "Charger", "Durango"],
     "Lincoln" => ["Navigator", "MKZ", "MKX", "MKS"],

--- a/lib/faker/vehicle/en.ex
+++ b/lib/faker/vehicle/en.ex
@@ -26,7 +26,7 @@ defmodule Faker.Vehicle.En do
     "Audi" => ["A4", "A5", "S5", "A7", "A8"],
     "Toyota" => ["Prius", "Camry", "Corolla"],
     "Chevrolet" => ["Camaro", "Silverado", "Malibu"],
-    "Ford" => ["Mustang", "F150", "Focus", "Fiesta"],
+    "Ford" => ["Mustang", "F-150", "Focus", "Fiesta"],
     "Dodge" => ["Ram", "Challenger", "Charger", "Durango"],
     "Lincoln" => ["Navigator", "MKZ", "MKX", "MKS"],
     "Buick" => ["Enclave", "Regal", "LaCrosse", "Verano", "Encore", "Riveria"],


### PR DESCRIPTION
Summary of changes:
- Update "Chevy" to the official spelling "Chevrolet"
- Fix spelling of "F-150" (the official name contains a hyphen)
- Fix spelling of "Camaro"
- Fix spelling of "Riviera"

I've added:

- [X] USAGE.md docs if applicable
- [X] CHANGELOG.md
