### PR TITLE
Add Elixir 1.16 and Elixir 1.17 to CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -112,6 +112,12 @@ jobs:
           - elixir: 1.15.x
             otp: 25.x
             os: ubuntu-20.04
+          - elixir: 1.16.x
+            otp: 25.x
+            os: ubuntu-20.04
+          - elixir: 1.17.0-rc.1
+            otp: 25.x
+            os: ubuntu-20.04
           # Something changed in otp 26 for seed and single test started producing failures
           # it does not affect functionality, only CI
           # - elixir: 1.15.x

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -115,9 +115,9 @@ jobs:
           - elixir: 1.16.x
             otp: 25.x
             os: ubuntu-20.04
-          - elixir: 1.17.0-rc.1
-            otp: 25.x
-            os: ubuntu-20.04
+          - elixir: 1.17.x
+            otp: 27.x
+            os: ubuntu-22.04
           # Something changed in otp 26 for seed and single test started producing failures
           # it does not affect functionality, only CI
           # - elixir: 1.15.x


### PR DESCRIPTION
Locally some tests are failing with this versions, let's see if on CI they work.
Elixir 1.17 failures are caused by [this change on Elixir](https://github.com/elixir-lang/elixir/commit/8e9cbfcd8c219f9d3558158f1ebee5ec4fadd762) 

I've added:

- [ ] USAGE.md docs if applicable
- [ ] CHANGELOG.md
